### PR TITLE
docs: add quickstart end-to-end section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,39 @@ poetry run pytest -q
 ./examples/run_quickstart_example.sh
 ```
 
+### Quickstart end-to-end
+
+Use este fluxo para reproduzir ingest → persist → snapshot → notebook:
+
+```bash
+cp .env.example .env
+poetry install
+poetry run main --help
+poetry run main --ticker PETR4 --force-refresh
+```
+
+Tickers de exemplo: `PETR4`, `VALE3`, `ITUB4`.
+
+Saídas esperadas:
+
+- `dados/data.db` → SQLite principal
+- `raw/<provider>/` → CSV bruto do provider
+- `snapshots/` → snapshots gerados + checksums
+
+Notebook de referência: `docs/examples/notebooks/returns-consumer.ipynb`
+
+Variáveis mínimas em `.env`:
+
+- `DEFAULT_TICKERS=PETR4,VALE3,ITUB4`
+- `DB_PATH=dados/data.db`
+- `SNAPSHOT_CACHE_FILE=dados/snapshot_cache.json`
+
+Troubleshooting rápido:
+
+- `poetry: command not found` → instale o Poetry antes de seguir o quickstart
+- `main --help` falha por import/local env → rode `python -m src.main --help`
+- Sem arquivos novos em `snapshots/` ou `raw/` → repita o comando com `--force-refresh`
+
 ### Modo de testes de rede (NETWORK_MODE)
 
 Para reduzir flakiness em CI, os testes que dependem de chamadas de rede rodam


### PR DESCRIPTION
Adds the missing quickstart guidance requested in #105.

- copy `.env.example` to `.env`
- install deps
- run help + ticker example
- documents `dados/`, `raw/`, `snapshots/` outputs
- links the notebook reference

/claim #105

## Summary by Sourcery

Document an end-to-end quickstart workflow in the README, covering setup, execution, outputs, configuration, and troubleshooting for running the main ticker ingestion flow.

Documentation:
- Add a Quickstart end-to-end section to the README that walks through copying env config, installing dependencies, running the main command with example tickers, and inspecting generated outputs.
- Document required environment variables and paths for database and snapshot cache configuration in the quickstart flow.
- Add brief troubleshooting guidance for common quickstart issues such as missing Poetry, import errors, and missing snapshot/raw outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Quickstart end-to-end" section to the README with a complete workflow covering data ingestion, persistence, and snapshot generation, including setup commands, example ticker inputs, expected outputs, and minimum environment variable configuration.
  * Added a troubleshooting checklist for common issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phbrgnomo/Analise-financeira-B3/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->